### PR TITLE
Variable Dimension ResNet Embeddings

### DIFF
--- a/source/evaluate/config.d/distribution/mixing/label/CIFAR10_embeddings.yaml
+++ b/source/evaluate/config.d/distribution/mixing/label/CIFAR10_embeddings.yaml
@@ -11,8 +11,8 @@ _subsamplers:
   transform:
     _target_: mutinfo.distributions.mixing.label.embedding_with_resnet18_backbone
     _partial_: true
-    device: "cuda:0"
-    checkpoint_path: ../python/mutinfo/misc/checkpoints/cifar10_supervised/best_model.pt
+    checkpoint_path: /home/foresti/mutinfo-stable/checkpoints/cifar10_supervised/best_model.pt
+    embeddings_dim: 16
   dataset:
     _target_: torchvision.datasets.CIFAR10 # List inside list.
     root: "./.cache"

--- a/source/evaluate/config.d/estimator/MINDE/MINDE-MLP.yaml
+++ b/source/evaluate/config.d/estimator/MINDE/MINDE-MLP.yaml
@@ -1,8 +1,11 @@
 # @package _global_
 
+name:
+  estimator: MINDE-MLP-${estimator.variant}
+
 estimator:
   _target_: mutinfo.estimators.parametric.minde.GenerativeMIEstimator
-  name: MINDE-Conv2d
+  name: MINDE-MLP
   variant: c
   backbone_factory:
     _target_: mutinfo.estimators.parametric.model.GenericMLPDiffuser
@@ -11,7 +14,7 @@ estimator:
   optimizer_factory:
     _target_: torch.optim.Adam
     _partial_: true
-    lr: 1e-2
+    lr: 1e-3
   logger:
     _target_: pytorch_lightning.loggers.WandbLogger
     project: tmlr
@@ -55,8 +58,11 @@ parameters_counter:
   _target_: builtins.eval
   _args_: ["lambda estimator, x, y: sum(parameters.numel() for parameters in estimator.backbone_factory(x.shape, y.shape).parameters())"]
 
+key:
+  estimator: ${name.estimator}
+
 hydra:
   sweeper:
     params:
       #++estimator.estimator.estimate_fraction: null, 0.5
-      ++estimator.backbone_factory.hidden_dim: 16
+      ++estimator.backbone_factory.hidden_dim: 128

--- a/source/python/mutinfo/distributions/mixing/__init__.py
+++ b/source/python/mutinfo/distributions/mixing/__init__.py
@@ -1,0 +1,2 @@
+from . import modulation
+from . import label

--- a/source/python/mutinfo/distributions/mixing/label.py
+++ b/source/python/mutinfo/distributions/mixing/label.py
@@ -108,62 +108,60 @@ def torchvision_default_transform(
 # TODO: move?
 def embedding_with_resnet18_backbone(
     dataset,
-    checkpoint_path: str=None,
-    dataloader_kwargs: dict={
-        "batch_size": 512,
-        "shuffle": False,
-    },
-    device: str="cpu",
+    checkpoint_path: str,
+    backbone_name: str="resnet18",
+    embeddings_dim: int=128,
 ) -> numpy.ndarray:
     """
-    Extract embeddings from CIFAR-10 images using a trained ResNet18 backbone.
-    
+    Extract embeddings from a torchvision dataset using a trained ResNet backbone
+    matching the ResNetClassifier architecture.
+
     Parameters
     ----------
-    x : numpy.ndarray
-        Input images with shape (N, H, W, C) or (N, C, H, W).
-        Values should be in range [0, 1] or [0, 255].
-    checkpoint_path : str, optional
-        Path to the checkpoint file. If None, uses the best model from resnet18_checkpoints/.
-    
+    dataset : torchvision Dataset
+        Dataset whose images will be embedded. The dataset's transform should
+        already apply the appropriate normalization (e.g. CIFAR-10 statistics).
+    checkpoint_path : str
+        Path to the checkpoint file saved by ResNetClassifier.
+    backbone_name : str
+        Torchvision backbone name (default: "resnet18").
+    embeddings_dim : int
+        Embedding dimension used when training the backbone (default: 128).
+
     Returns
     -------
     embeddings : numpy.ndarray
-        Feature embeddings with shape (N, 512) for ResNet18.
+        Feature embeddings with shape (N, embeddings_dim).
+    targets : numpy.ndarray
+        Corresponding labels with shape (N,).
     """
-    
     import torch
-    import torch.nn as nn
     import torchvision
-    from pathlib import Path
-    
-    device = torch.device(device)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
     checkpoint = torch.load(checkpoint_path, map_location=device)
-    
-    # Adapt backbone for CIFAR-10 (from supervised_learning_cifar10.py).
-    def adapt_backbone_to_CIFAR(backbone):
-        backbone.conv1 = torch.nn.Conv2d(3, 64, kernel_size=(3, 3), stride=1, padding=(1, 1))
-        backbone.maxpool = torch.nn.Identity()
-        return backbone
-    
-    # Create model.
-    backbone = torchvision.models.resnet18(num_classes=128)
-    backbone = adapt_backbone_to_CIFAR(backbone)
-    backbone.fc = nn.Linear(512, 10)  # Match the saved model structure.
-    
-    # Load weights - strip "backbone." prefix from checkpoint keys.
-    state_dict = checkpoint['model_state_dict']
-    state_dict = {k.replace('backbone.', ''): v for k, v in state_dict.items() if k.startswith('backbone.')}
-    backbone.load_state_dict(state_dict)
-    
-    # Remove final classification layer to extract embeddings.
-    backbone.fc = nn.Identity()
+    state_dict = checkpoint.get('model_state_dict', checkpoint)
+
+    # Build backbone matching ResNetClassifier exactly:
+    # getattr(torchvision.models, backbone_name)(num_classes=embeddings_dim)
+    # + CIFAR adaptation (3x3 conv1, no maxpool)
+    backbone = getattr(torchvision.models, backbone_name)(num_classes=embeddings_dim)
+    backbone.conv1 = torch.nn.Conv2d(3, 64, kernel_size=(3, 3), stride=1, padding=(1, 1))
+    backbone.maxpool = torch.nn.Identity()
+
+    backbone_sd = {
+        k[len('backbone.'):]: v
+        for k, v in state_dict.items()
+        if k.startswith('backbone.')
+    }
+    backbone.load_state_dict(backbone_sd, strict=True)
+
     backbone = backbone.to(device)
     backbone.eval()
 
-    # Use dataloader for batched processing.
-    dataloader = torch.utils.data.DataLoader(dataset, **dataloader_kwargs)
-    
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=512, shuffle=False)
+
     # Extract embeddings
     embeddings = []
     targets = []

--- a/source/python/mutinfo/misc/supervised_learning_cifar10.py
+++ b/source/python/mutinfo/misc/supervised_learning_cifar10.py
@@ -71,12 +71,12 @@ class ResNetClassifier(nn.Module):
         # Load backbone
         backbone = getattr(torchvision.models, backbone_name)(num_classes=embeddings_dim)
         self.backbone = adapt_backbone_to_CIFAR(backbone)
-        
-        # Replace the final FC layer for CIFAR-10 classification
-        self.backbone.fc = nn.Linear(512, num_classes)  # ResNet18 has 512 features
-        
+
+        self.fc = nn.Linear(embeddings_dim, num_classes)
+
     def forward(self, x):
-        return self.backbone(x)
+        embs = self.backbone(x)
+        return self.fc(embs)
 
 
 def train_epoch(model, trainloader, criterion, optimizer, device):


### PR DESCRIPTION
# Feature: Allow custom embedding dimensionality for CIFAR10

## Context
Previously, the embedding dimensionality for CIFAR10 was hardcoded at 512. This PR allows users to specify custom embedding dimensions, which is necessary for experimenting with smaller latent spaces.

## Key Changes
- **ResNet Architecture:** Updated the CIFAR10 supervised learning architecture to accept a custom embedding dimension parameter.
- **Config Updates:** Cleaned up outdated config files to align with the new parameter requirements.